### PR TITLE
Support for matching version episodes.

### DIFF
--- a/horriblesubs-api.js
+++ b/horriblesubs-api.js
@@ -312,8 +312,8 @@ module.exports = class HorribleSubsAPI {
 
             const season = 1;
 
-            const seasonal = /(.*).[Ss](\d)\s-\s(\d+).\[(\d{3,4}p)\]/i;
-            const oneSeason = /(.*)\s-\s(\d+).\[(\d{3,4}p)\]/i;
+            const seasonal = /(.*).[Ss](\d)\s-\s(\d+)(?:v\d)?.\[(\d{3,4}p)\]/i;
+            const oneSeason = /(.*)\s-\s(\d+)(?:v\d)?.\[(\d{3,4}p)\]/i;
             let slug, episode, quality;
             if (label.match(seasonal)) {
               data.slug = label.match(seasonal)[1].replace(/[,!]/gi, '').replace(/\s-\s/gi, ' ').replace(/[\+\s\']/g, '-').toLowerCase();


### PR DESCRIPTION
It appears that HorribleSubs replaces an episode and changes the name of the episode to 31v2 in some cases.
This resulted in the getAnimeData result not showing result for episode 31 in this example: http://horriblesubs.info/shows/shingeki-no-kyojin

This adds support to match with such cases.